### PR TITLE
expose jwt through next-auth session

### DIFF
--- a/src/ui/pages/api/auth/[...nextauth].js
+++ b/src/ui/pages/api/auth/[...nextauth].js
@@ -14,12 +14,14 @@ export const authOptions = {
       // Persist the OAuth access_token to the token right after signin
       if (account) {
         token.accessToken = account.access_token;
+        token.jwt = account.id_token;
       }
       return token;
     },
     async session({session, token, user}) {
       // Send properties to the client, like an access_token from a provider.
       session.accessToken = token.accessToken;
+      session.jwt = token.jwt;
       return session;
     },
   },


### PR DESCRIPTION
This PR exposes the account JWT to the next-auth session. Example:

```
import {useSession} from 'next-auth/react';

...

const {data: session} = useSession()
console.log(session)
```

Will output something like:

```json
{
  "user": {
    "name": "Nic Nolan",
    "email": "nolann@oregonstate.edu",
    "image": "https://lh3.googleusercontent.com/a/ALm5wu1mApecOnG7MuXt0O-oQrua8ZIGuCBj7Ni6-zHN=s96-c"
  },
  "expires": "2022-11-19T19:21:51.364Z",
  "accessToken": "ya29.a0Aa4xrXNpo4gvxTMy0jWwRWiwX2UDgga5uqHcc91ZerjGxkrlelIVEBlYTRiLVk3GdKxjby990kT2KdxkCHNbIoMifgnqPllUk6BMKg2Bm_UF-FzFS3X3ul2Dkkds-L93oDyxJz8nJEmk-zucZzN_dLNoptiTBAaCgYKATASAQ8SFQEjDvL9OdQIqbZ8jfs3UOrsdLYwtw0165",
  "jwt": "[redacted]"
}
```